### PR TITLE
Support editing of recipe description and ingredients in Grav Admin.

### DIFF
--- a/blueprints/item.yaml
+++ b/blueprints/item.yaml
@@ -1,0 +1,50 @@
+title: Item
+'@extends':
+    type: default
+    context: blueprints://pages
+
+form:
+  fields:
+    tabs:
+      fields:
+        recipe-options:
+          type: tab
+          title: ADMIN.RECIPE
+          fields:
+            Description:
+              type: section
+              title: ADMIN.DESCRIPTION
+              underline: true
+            header.description:
+              name: description
+              type: list
+              label: ADMIN.DESCRIPTION_LABEL
+              fields:
+                .option:
+                  type: text
+                  label: ADMIN.OPTION
+                .value:
+                  type: text
+                  label: ADMIN.VALUE
+
+            Ingredients:
+              type: section
+              title: ADMIN.INGREDIENTS
+              underline: true
+            header.ingredients_title:
+              name: ingredients_title
+              type: text
+              label: ADMIN.INGREDIENTS_TITLE
+              default: ADMIN.INGREDIENTS
+            header.ingredients:
+              name: ingredients
+              type: list
+              label: ADMIN.INGREDIENTS
+              fields:
+                .title:
+                  type: text
+                  label: ADMIN.COLUMN_TITLE
+                .list:
+                  type: array
+                  label: ADMIN.INGREDIENTS
+                  value_only: true

--- a/blueprints/item.yaml
+++ b/blueprints/item.yaml
@@ -35,7 +35,6 @@ form:
               name: ingredients_title
               type: text
               label: ADMIN.INGREDIENTS_TITLE
-              default: ADMIN.INGREDIENTS
             header.ingredients:
               name: ingredients
               type: list

--- a/languages.yaml
+++ b/languages.yaml
@@ -3,6 +3,15 @@ en:
     TITLE: My Blog
     DESCRIPTION: Blogging about stuff
     COPYRIGHT: © Copyright %s Your Company
+  ADMIN:
+    RECIPE: Recipe
+    DESCRIPTION: Description
+    DESCRIPTION_LABEL: Advanced recipe description
+    OPTION: Option
+    VALUE: Value
+    INGREDIENTS: Ingredients
+    INGREDIENTS_TITLE: Heading
+    COLUMN_TITLE: Column heading
   SUBSCRIBE: Subscribe
   TWEET: Tweet
   SHARE: Share
@@ -60,6 +69,15 @@ de:
     TITLE: Mein Blog
     DESCRIPTION: Blogging über dies und das
     COPYRIGHT: © Copyright %s deine Firma
+  ADMIN:
+    RECIPE: Rezept
+    DESCRIPTION: Beschreibung
+    DESCRIPTION_LABEL: Erweiterte Beschreibung des Rezepts
+    OPTION: Option
+    VALUE: Wert
+    INGREDIENTS: Zutaten
+    INGREDIENTS_TITLE: Überschrift
+    COLUMN_TITLE: Spaltentitel
   SUBSCRIBE: Abonnieren
   TWEET: Tweeten
   SHARE: Teilen


### PR DESCRIPTION
The blueprint adds a "Recipe" tab in the Admin plugin when editing a Blog Item, so the user can edit recipe ingredients etc. without manually touching the YAML.